### PR TITLE
Improvements for MacOS recent versions, amazon linux and centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ Linux distro and BSD flavor detection after 1.0 is based on [screenFetch](https:
 - [x] macOS ~~Mac OS X~~
 - [x] Windows
 - [ ] Arch Linux
+- [x] Amazon Linux
 - [x] Fedora
 - [x] Linux Mint
 - [x] Ubuntu
 - [x] Debian
+- [x] CentOS
 - [ ] Crunchbang
 - [ ] Gentoo
 - [ ] Funtoo
@@ -69,7 +71,7 @@ Linux distro and BSD flavor detection after 1.0 is based on [screenFetch](https:
 - [x] OpenSUSE
 - [ ] Mandriva/Mandrake
 - [ ] Slackware
-- [ ] Red Hat (RHEL)
+- [x] Red Hat (RHEL)
 - [ ] Frugalware
 - [x] Peppermint
 - [ ] SolusOS

--- a/src/main/java/nu/redpois0n/oslib/bsd/BSDOperatingSystem.java
+++ b/src/main/java/nu/redpois0n/oslib/bsd/BSDOperatingSystem.java
@@ -19,11 +19,11 @@ public class BSDOperatingSystem extends UnixOperatingSystem implements Serializa
     }
 
     public BSDOperatingSystem() {
-        this(Flavor.getLocalFlavor(), LinuxDetector.getArchLinux());
+        this(Flavor.getLocalFlavor(), LinuxDetector.getLinuxArch());
     }
 
     public BSDOperatingSystem(Flavor flavor) {
-        this(flavor, LinuxDetector.getArchLinux());
+        this(flavor, LinuxDetector.getLinuxArch());
     }
 
     public Flavor getFlavor() {

--- a/src/main/java/nu/redpois0n/oslib/linux/Distro.java
+++ b/src/main/java/nu/redpois0n/oslib/linux/Distro.java
@@ -5,6 +5,7 @@ import nu.redpois0n.oslib.UnsupportedOperatingSystemException;
 public enum Distro {
 
     ALPINE("Alpine Linux", "alpine", new FileExistsType("/etc/arch-release")),
+    AMAZON("Amazon Linux", "amazon", new FileContainsType("/etc/os-release", "amzn")),
     ANTERGOS("Antergos"),
     ARCH_LINUX("Arch Linux", "archlinux", "archarm"),
     BLAG("BLAG"),

--- a/src/main/java/nu/redpois0n/oslib/linux/DistroDetector.java
+++ b/src/main/java/nu/redpois0n/oslib/linux/DistroDetector.java
@@ -23,7 +23,7 @@ public class DistroDetector {
                 lsbRelease = Utils.readProcess(new String[]{"lsb_release", "-irc"});
                 lsbReleaseExists = lsbRelease.size() == 3;
             } catch (Exception ex) {
-                ex.printStackTrace();
+                System.out.println("Failed to execute lsb_release -irc");
             }
 
             Map<String, String> osreleaseMap = null;

--- a/src/main/java/nu/redpois0n/oslib/linux/DistroDetector.java
+++ b/src/main/java/nu/redpois0n/oslib/linux/DistroDetector.java
@@ -124,7 +124,7 @@ public class DistroDetector {
                     }
                 }
 
-                if (distro == null && lsbreleaseMap != null) {
+                if (distro == null && lsbreleaseMap != null && osreleaseMap != null) {
                     String distribid = osreleaseMap.get("DISTRIB_ID");
 
                     if (distribid != null) {

--- a/src/main/java/nu/redpois0n/oslib/linux/DistroDetector.java
+++ b/src/main/java/nu/redpois0n/oslib/linux/DistroDetector.java
@@ -41,6 +41,19 @@ public class DistroDetector {
                 System.out.println("Failed to load /etc/lsb-release");
             }
 
+            // to detect older versions of centos (as centos 6), which don't have /etc/os-release
+            // CentOS Linux 6.10 (Final)
+            try {
+                List<String> lines = Utils.readFile(new File("/etc/centos-release"));
+                if (lines.size() > 0) {
+                    String content = lines.get(0);
+                    distro = Distro.CENTOS;
+                    release = content.split(" ")[2];
+                }
+            } catch (Exception ex) {
+                System.out.println("Failed to load /etc/centos-release");
+            }
+
             boolean b = false;
 
             for (Distro d : Distro.values()) {

--- a/src/main/java/nu/redpois0n/oslib/linux/LinuxDetector.java
+++ b/src/main/java/nu/redpois0n/oslib/linux/LinuxDetector.java
@@ -19,7 +19,7 @@ public class LinuxDetector {
         return false;
     }
 
-    public static Arch getArchLinux() {
+    public static Arch getLinuxArch() {
         InputStream is = null;
         try {
             final Process process = Runtime.getRuntime().exec(new String[]{"uname", "-m"});

--- a/src/main/java/nu/redpois0n/oslib/linux/LinuxOperatingSystem.java
+++ b/src/main/java/nu/redpois0n/oslib/linux/LinuxOperatingSystem.java
@@ -13,7 +13,7 @@ public class LinuxOperatingSystem extends UnixOperatingSystem implements Seriali
     private final DistroSpec ds;
 
     public LinuxOperatingSystem(Distro d) {
-        this(new DistroSpec(d), LinuxDetector.getArchLinux());
+        this(new DistroSpec(d), LinuxDetector.getLinuxArch());
     }
 
     public LinuxOperatingSystem(DistroSpec ds, Arch arch) {
@@ -22,11 +22,11 @@ public class LinuxOperatingSystem extends UnixOperatingSystem implements Seriali
     }
 
     public LinuxOperatingSystem() {
-        this(Distro.getLocalDistroSpec(), LinuxDetector.getArchLinux());
+        this(Distro.getLocalDistroSpec(), LinuxDetector.getLinuxArch());
     }
 
     public LinuxOperatingSystem(DistroSpec ds) {
-        this(ds, LinuxDetector.getArchLinux());
+        this(ds, LinuxDetector.getLinuxArch());
     }
 
     public Distro getDistro() {

--- a/src/main/java/nu/redpois0n/oslib/macos/MacOSOperatingSystem.java
+++ b/src/main/java/nu/redpois0n/oslib/macos/MacOSOperatingSystem.java
@@ -23,7 +23,7 @@ public class MacOSOperatingSystem extends UnixOperatingSystem implements Seriali
     }
 
     public MacOSOperatingSystem(MacOSVersion version) {
-        this(version, LinuxDetector.getArchLinux());
+        this(version, LinuxDetector.getLinuxArch());
     }
 
     public void setVersion(MacOSVersion version) {

--- a/src/main/java/nu/redpois0n/oslib/macos/MacOSVersion.java
+++ b/src/main/java/nu/redpois0n/oslib/macos/MacOSVersion.java
@@ -16,7 +16,9 @@ public enum MacOSVersion implements VersionCompare {
     MAVERICKS("Mavericks", "10.9", true),
     YOSEMITE("Yosemite", "10.10", true),
     EL_CAPITAN("El Capitan", "10.11", true),
-    SIERRA("Sierra", "10.12");
+    SIERRA("Sierra", "10.12"),
+    HIGH_SIERRA("High Sierra", "10.13", true),
+    MOJAVE("Mojave", "10.14", true);
 
     private final String search;
     private final String version;
@@ -66,8 +68,33 @@ public enum MacOSVersion implements VersionCompare {
      * Gets MacOSVersion from string Will detect "10.11.*" if parameter search is is "10.11"
      */
     public static MacOSVersion getFromString(String search) {
+        // check for one with exact match
+        MacOSVersion exactRes = getExactFromVersion(search);
+        if (exactRes != null) {
+            return exactRes;
+        }
+
         for (MacOSVersion v : MacOSVersion.values()) {
             if (search.startsWith(v.getVersion()) || v.getDisplay().toLowerCase().contains(search.toLowerCase())) {
+                return v;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets MacOSVersion by doing an exact match on major and minor version.
+     * if parameter search is "10.14.5", look for "10.14", considering MacOS history of version numbers
+     */
+    public static MacOSVersion getExactFromVersion(String search) {
+        String[] versionSplit = search.split("\\.");
+        if (versionSplit.length >= 2) {
+            versionSplit = new String[]{versionSplit[0], versionSplit[1]};
+        }
+        String majorMinorVersion = String.join(".", versionSplit);
+        for (MacOSVersion v: MacOSVersion.values()) {
+            if (v.getVersion().equals(majorMinorVersion)) {
                 return v;
             }
         }


### PR DESCRIPTION
Hi @wille,
Thanks for building this. I have been using this for some project, and have made some changes to fit my needs.
Here they are for your upstream branch.

Following changes have been done
- Add support for Amazon Linux
- Test out on RHEL, CentOS
- Add support for distro info for CentOS 6, which doesn't have either of `/etc/os-release`, or `/etc/lsb-release`, but `/etc/centos-release`
- Refactor `getArchLinux` to `getLinuxArch`
- Avoid throwing stack trace when `lsb_release` isn't available

Let me know if there's something I can help with.

PS: I would recommend having this library in mavenCentral for ease of usage.