### PR TITLE
Add arm64 arch support

### DIFF
--- a/src/main/java/nu/redpois0n/oslib/Arch.java
+++ b/src/main/java/nu/redpois0n/oslib/Arch.java
@@ -4,7 +4,7 @@ public enum Arch {
 
     x86("x86", "i386", "i486", "i586", "i686"),
     x86_64("x86_64", "amd64", "k8"),
-    ARM("ARM"),
+    ARM("ARM", "arm64"),
     UNKNOWN("Unknown");
 
     private final String[] search;


### PR DESCRIPTION
# Background
Now we don't recognize arm architecture when it's presented as arm64. This makes it hard to recognize the new Apple Silicon MacBook.

# Changes
- Add `arm64` keyword

# Test plan
- Run test on MacBook on Apple Silicon
- Check that all work correctly